### PR TITLE
Hide home timeline.

### DIFF
--- a/js/twitter.js
+++ b/js/twitter.js
@@ -130,7 +130,7 @@ function showAppropriateDomElements() {
                     // Hide home timeline
                     if (elementsToHide.includes('home_timeline')) {
                         element.style.setProperty('display', 'none');
-                    };
+                    }
                     if (oHTML.includes('data-testid="tweet"')) {
                         if (elementsToHide.includes('ads') && oHTML.includes('Promoted')) {
                             let p = goUp(5, element);

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -23,6 +23,7 @@ rMap.set('right_banner', '[data-testid="sidebarColumn"]');
 
 // Main Column Elements
 let cMap = new Map();
+cMap.set('home_timeline', '[aria-label="Timeline: Your Home Timeline"]');
 cMap.set('new_tweet_notification', '[role="status"]');
 cMap.set('tweet_box', '[aria-label="Tweet"],[data-testid="reply"],.DraftEditor-root');
 cMap.set('reply', '[data-testid="reply"]');
@@ -126,6 +127,10 @@ function showAppropriateDomElements() {
             if (centerSelectorsToHide.length > 0) {
                 watchForNewArrivals(centerSelectorsToHide, function(element) {
                     let oHTML = element['outerHTML'];
+                    // Hide home timeline
+                    if (elementsToHide.includes('home_timeline')) {
+                        element.style.setProperty('display', 'none');
+                    };
                     if (oHTML.includes('data-testid="tweet"')) {
                         if (elementsToHide.includes('ads') && oHTML.includes('Promoted')) {
                             let p = goUp(5, element);

--- a/options.html
+++ b/options.html
@@ -49,6 +49,7 @@
                                 <ul>
                                     <li class="option_section_header"><label>Timeline</label></li>
                                     <ul id="main_details">
+                                        <li><label><input type="checkbox" id="home_timeline" title="Home Timeline">Home Timeline</label></li>
                                         <li><label><input type="checkbox" id="new_tweet_notification" title="Hide New Tweets Notification">New Tweets Notification</label></li>
                                         <li><label><input type="checkbox" id="tweet_box" title="Disable Tweeting">Disable Tweeting</label></li>
                                         <li><label><input type="checkbox" id="reply" title="Hide Reply Button">Reply Button</label></li>


### PR DESCRIPTION
Addressing https://github.com/grantwinney/twitter-tamer/issues/9
Only tested on Chrome.
Preview:
<img width="568" alt="2020-02-02_21-27" src="https://user-images.githubusercontent.com/22290018/73608856-d4113d80-4602-11ea-91c9-e597369f690e.png">
![FireShot Capture 002 - Home _ Twitter - twitter com](https://user-images.githubusercontent.com/22290018/73608857-d6739780-4602-11ea-8b81-804059d9dc30.png)
